### PR TITLE
optional unit and height in lines

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,12 @@ Simply include ` {x}` at the end of the captions for figures that are to be wrap
 that specifies the width of the wrap in inches. Setting it to 0 will cause the width of the figure
 to be used (as per the wrapfig package instructions). Figures without the tag will float as usual.
 
+To use a specific  length, you may also add `cm`,`pt`or `in` like `{5cm}`.
+
+Also, wrapfig allows optional specification of the "number of narrow lines" that are aquivalent to 
+height of the image. Though guessed by wrapfig, this sometimes has to be adjusted. This is possible 
+by adding a second number to the `{}` argument like: `{5cm,28}`.
+
 Wrapping is specific to pdf/LaTeX output. For other formats, the tag is simply removed.
 
 [pandoc]: http://pandoc.org

--- a/pandoc-wrapfig.py
+++ b/pandoc-wrapfig.py
@@ -12,7 +12,7 @@ cause the width of the figure to be used.
 from pandocfilters import toJSONFilter, Image, RawInline, stringify
 import re, sys
 
-FLAG_PAT = re.compile('.*\{(\d+\.?\d?)\}')
+FLAG_PAT = re.compile('.*\{(\d+\.?\d?(cm|in|pt)*)\,*(\d*)\}')
 
 def wrapfig(key, val, fmt, meta):
     if key == 'Image':
@@ -20,9 +20,13 @@ def wrapfig(key, val, fmt, meta):
         if FLAG_PAT.match(stringify(caption)):
             # Strip tag
             size = FLAG_PAT.match(caption[-1]['c']).group(1)
+            lines = FLAG_PAT.match(caption[-1]['c']).group(3)
             stripped_caption = caption[:-2]
             if fmt == 'latex':
-                latex_begin = r'\begin{wrapfigure}{r}{' + size + 'in}'
+                if len(lines) > 0:
+                    latex_begin = r'\begin{wrapfigure}[' + lines + ']{l}{' + size + '}'
+                else:
+                    latex_begin = r'\begin{wrapfigure}{l}{' + size + '}'
                 if len(stripped_caption) > 0:
                     latex_fig = r'\centering\includegraphics{' + target[0] \
                                 + '}\caption{'


### PR DESCRIPTION
You may also set a unit (cm,pt or in) and the optional "number of narrow lines" (see [wrapfig doc](http://ftp.fau.de/ctan/macros/latex/contrib/wrapfig/wrapfig-doc.pdf)) argument separated by a komma (,).
e.g.:

````
![Caption {5cm,28}](path/to/image.png)
````